### PR TITLE
feat: Updating the github action to use the latest version of Plantuml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,6 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://holowinski/plantuml:1.2020.23"
+  image: "docker://dstockhammer/plantuml:latest"
   args:
     - ${{ inputs.args }}


### PR DESCRIPTION
The docker image is now latest from https://hub.docker.com/r/dstockhammer/plantuml/tags. They seem to keep their docker image up to date. Plantuml doesn't seem to publish an image for plantuml cli; only the server option.